### PR TITLE
Shrink dependency tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ description = "Global variables without macros."
 repository = "https://github.com/overdrivenpotato/global"
 
 [dependencies]
-parking_lot = "0.8.0"
+parking_lot = "0.9.0"


### PR DESCRIPTION
`parking_lot` v0.9 sheds considerable weight.

Dependency tree before:
```
global v0.4.0 (/home/greg/Workspace/global)
└── parking_lot v0.8.0
    ├── lock_api v0.2.0
    │   └── scopeguard v1.0.0
    └── parking_lot_core v0.5.0
        ├── cfg-if v0.1.10
        ├── libc v0.2.62
        ├── rand v0.6.5
        │   ├── libc v0.2.62 (*)
        │   ├── rand_chacha v0.1.1
        │   │   └── rand_core v0.3.1
        │   │       └── rand_core v0.4.2
        │   │   [build-dependencies]
        │   │   └── autocfg v0.1.6
        │   ├── rand_core v0.4.2 (*)
        │   ├── rand_hc v0.1.0
        │   │   └── rand_core v0.3.1 (*)
        │   ├── rand_isaac v0.1.1
        │   │   └── rand_core v0.3.1 (*)
        │   ├── rand_jitter v0.1.4
        │   │   └── rand_core v0.4.2 (*)
        │   ├── rand_os v0.1.3
        │   │   ├── libc v0.2.62 (*)
        │   │   └── rand_core v0.4.2 (*)
        │   ├── rand_pcg v0.1.2
        │   │   └── rand_core v0.4.2 (*)
        │   │   [build-dependencies]
        │   │   └── autocfg v0.1.6 (*)
        │   └── rand_xorshift v0.1.1
        │       └── rand_core v0.3.1 (*)
        │   [build-dependencies]
        │   └── autocfg v0.1.6 (*)
        └── smallvec v0.6.10
        [build-dependencies]
        └── rustc_version v0.2.3
            └── semver v0.9.0
                └── semver-parser v0.7.0
    [build-dependencies]
    └── rustc_version v0.2.3 (*)
```

After:
```
global v0.4.0 (/home/greg/Workspace/global)
└── parking_lot v0.9.0
    ├── lock_api v0.3.1
    │   └── scopeguard v1.0.0
    └── parking_lot_core v0.6.2
        ├── cfg-if v0.1.10
        ├── libc v0.2.62
        └── smallvec v0.6.10
        [build-dependencies]
        └── rustc_version v0.2.3
            └── semver v0.9.0
                └── semver-parser v0.7.0
    [build-dependencies]
    └── rustc_version v0.2.3 (*)
```

All tests are passing.