### PR TITLE
Rewrite using MaybeUninit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ edition = "2018"
 
 [dependencies]
 parking_lot = "0.9.0"
+criterion = { version = "0.3.0", optional = true }
 
-[dev-dependencies]
-criterion = "0.3.0"
+[features]
+default = []
+bench = ["criterion"]
 
 [[bench]]
 name = "immutable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Marko Mijalkovic <marko.mijalkovic97@gmail.com>"]
 
 description = "Global variables without macros."
 repository = "https://github.com/overdrivenpotato/global"
+edition = "2018"
 
 [dependencies]
 parking_lot = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,10 @@ edition = "2018"
 
 [dependencies]
 parking_lot = "0.9.0"
+
+[dev-dependencies]
+criterion = "0.3.0"
+
+[[bench]]
+name = "immutable"
+harness = false

--- a/benches/immutable.rs
+++ b/benches/immutable.rs
@@ -1,0 +1,34 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use global::Immutable;
+use std::time::Duration;
+
+fn run_benchmarks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("simple");
+    group.bench_function("million_gets", |b| b.iter(|| {
+        let n = black_box(1_000_000);
+        (0..n).for_each(|_| {
+            static N: Immutable<i32> = Immutable::new();
+            &*N;
+        });
+    }));
+    group.finish();
+
+    let mut group = c.benchmark_group("throughput");
+    // one access per iteration
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("get_global", |b| {
+        b.iter(|| {
+            static N: Immutable<i32> = Immutable::new();
+            &*N;
+        })
+    });
+    group.finish();
+}
+
+fn main() {
+    let mut c = Criterion::default()
+        // bump warm-up time from 3s to prevent false regression reports
+        .warm_up_time(Duration::from_secs_f32(7.5));
+
+    run_benchmarks(&mut c);
+}

--- a/benches/immutable.rs
+++ b/benches/immutable.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{black_box, Criterion, Throughput};
 use global::Immutable;
 use std::time::Duration;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(test)]
 //! Type-level safe mutable global access, with support for recursive immutable
 //! locking.
 //!
@@ -31,7 +30,7 @@ use std::{
     sync::Arc,
     ops::{Deref, DerefMut},
     cell::{self, RefCell},
-    mem::ManuallyDrop,
+    mem::{MaybeUninit, ManuallyDrop}
 };
 
 use parking_lot::{Once, ReentrantMutex, ReentrantMutexGuard};
@@ -292,7 +291,7 @@ impl<T: 'static> Deref for GlobalGuard<T> {
 /// [`Default`]: https://doc.rust-lang.org/std/default/trait.Default.html
 pub struct Immutable<T> {
     once: Once,
-    inner: std::mem::MaybeUninit<T>,
+    inner: MaybeUninit<T>,
 }
 
 unsafe impl<T: Send> Send for Immutable<T> {}
@@ -319,7 +318,7 @@ impl<T> Immutable<T> {
     pub const fn new() -> Self {
         Self {
             once: Once::new(),
-            inner: std::mem::MaybeUninit::uninit()
+            inner: MaybeUninit::uninit()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,9 +327,10 @@ impl<T: Default> Deref for Immutable<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        // Unwrap cannot panic, we called `ensure_exists`.
         self.ensure_exists();
         unsafe {
+            // safe to deref this pointer as `ensure_exists()` prevents
+            // it from being null or dangling
             &*self.inner.as_ptr()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(test)]
 //! Type-level safe mutable global access, with support for recursive immutable
 //! locking.
 //!
@@ -350,7 +351,8 @@ mod test {
         time::Duration,
     };
 
-    use super::Global;
+    use super::{Immutable, Global};
+    extern crate test;
 
     #[test]
     fn no_race_condition() {
@@ -467,5 +469,17 @@ mod test {
         t.join().unwrap();
 
         assert_eq!(2, *NUM.lock().unwrap());
+    }
+
+    #[bench]
+    fn simple(b: &mut test::Bencher) {
+        b.iter(|| {
+            let n = test::black_box(1_000_000);
+            (0..n).for_each(|_| {
+                static N: Immutable<i32> = Immutable::new();
+                &*N;
+            });
+
+        });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,7 @@ mod test {
         time::Duration,
     };
 
-    use super::{Immutable, Global};
+    use super::Global;
 
     #[test]
     fn no_race_condition() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,6 @@ mod test {
     };
 
     use super::{Immutable, Global};
-    extern crate test;
 
     #[test]
     fn no_race_condition() {
@@ -461,17 +460,5 @@ mod test {
         t.join().unwrap();
 
         assert_eq!(2, *NUM.lock().unwrap());
-    }
-
-    #[bench]
-    fn benchmark_immutable(b: &mut test::Bencher) {
-        b.iter(|| {
-            let n = test::black_box(1_000_000);
-            (0..n).for_each(|_| {
-                static N: Immutable<i32> = Immutable::new();
-                &*N;
-            });
-
-        });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(test, maybe_uninit_extra, maybe_uninit_ref)]
+#![feature(test)]
 //! Type-level safe mutable global access, with support for recursive immutable
 //! locking.
 //!
@@ -331,7 +331,7 @@ impl<T: Default> Deref for Immutable<T> {
         // Unwrap cannot panic, we called `ensure_exists`.
         self.ensure_exists();
         unsafe {
-            self.inner.get_ref()
+            &*self.inner.as_ptr()
         }
     }
 }


### PR DESCRIPTION
- Add benchmarks for `Immutable`, measuring throughput and batch accesses 
- Use `MaybeUninit<T>` instead of `UnsafeCell`
  - ~1.8x performance increase